### PR TITLE
Adds OpenMP support for AppleClang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.9)
 project (isotree VERSION 0.1.17)
 set(CMAKE_BUILD_TYPE Release)
 
@@ -24,11 +24,10 @@ set_target_properties(isotree PROPERTIES PUBLIC_HEADER ${PROJECT_SOURCE_DIR}/inc
 
 add_compile_definitions(_USE_MERSENNE_TWISTER)
 
-## https://stackoverflow.com/questions/12399422/how-to-set-linker-flags-for-openmp-in-cmakes-try-compile-function
+## https://cliutils.gitlab.io/modern-cmake/chapters/packages/OpenMP.html
 find_package(OpenMP)
-if (OPENMP_FOUND)
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(isotree PUBLIC OpenMP::OpenMP_CXX)
 else()
 	message(STATUS "OpenMP not found - will compile without multi-threading support")
 endif()


### PR DESCRIPTION
Hi, currently, IsoTree fails to build with AppleClang and OpenMP (from `brew install libomp`) on Mac.

```sh
[ 92%] Building CXX object CMakeFiles/isotree.dir/src/utils.cpp.o
[100%] Linking CXX shared library libisotree.dylib
Undefined symbols for architecture x86_64:
  "___kmpc_barrier", referenced from:
      check_for_missing(InputData&, std::__1::vector<ImputedData, std::__1::allocator<ImputedData> >&, std::__1::unordered_map<unsigned long, ImputedData, std::__1::hash<unsigned long>, std::__1::equal_to<unsigned long>, std::__1::allocator<std::__1::pair<unsigned long const, ImputedData> > >&, int) in impute.cpp.o
  "___kmpc_critical", referenced from:
      set_interrup_global_variable(int) in utils.cpp.o
  "___kmpc_dispatch_init_8u", referenced from:
      _.omp_outlined. in dist.cpp.o
      _.omp_outlined..1 in dist.cpp.o
      _.omp_outlined. in fit_model.cpp.o
      _.omp_outlined. in impute.cpp.o
      _.omp_outlined..1 in impute.cpp.o
      _.omp_outlined..3 in impute.cpp.o
      _.omp_outlined..5 in impute.cpp.o
      ...

```

CMake 3.9+ significantly improves OpenMP support: https://cliutils.gitlab.io/modern-cmake/chapters/packages/OpenMP.html

Another option that works (without bumping the minimum CMake version) is the approach taken by LightGBM: https://github.com/microsoft/LightGBM/blob/33af069cc174a4c56c5f1e2f351196a284248f80/CMakeLists.txt#L295-L298

Or we could conditionally require 3.9 for Mac.

```cmake
if(APPLE)
  cmake_minimum_required(VERSION 3.9)
else()
  cmake_minimum_required(VERSION 3.8)
endif()
```

Let me know what you think.