### PR TITLE
Added missing cmath include

### DIFF
--- a/include/isotree.hpp
+++ b/include/isotree.hpp
@@ -62,6 +62,7 @@
 */
 
 /* Standard headers */
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <vector>


### PR DESCRIPTION
If you move `#include "isotree.hpp"` to the top of `example/isotree_cpp_ex.cpp` and try to compile, it'll error with:

```text
In file included from example/isotree_cpp_ex.cpp:1:
./include/isotree.hpp:133:28: error: use of undeclared identifier 'HUGE_VAL'
    double   range_low  = -HUGE_VAL;
                           ^
./include/isotree.hpp:134:28: error: use of undeclared identifier 'HUGE_VAL'
    double   range_high =  HUGE_VAL;
                           ^
./include/isotree.hpp:155:28: error: use of undeclared identifier 'HUGE_VAL'
    double   range_low  = -HUGE_VAL;
                           ^
./include/isotree.hpp:156:28: error: use of undeclared identifier 'HUGE_VAL'
    double   range_high =  HUGE_VAL;
                           ^
4 errors generated.
```

This PR adds `cmath`, where `HUGE_VAL` is defined:  https://en.cppreference.com/w/cpp/numeric/math/HUGE_VAL
