### PR TITLE
Decrease required NumPy version from 1.25 to 1.24

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["cython>=3.0.0", "setuptools", "wheel", "numpy>=1.25"]
+requires = ["cython>=3.0.0", "setuptools", "wheel", "numpy>=1.24"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pandas>=0.24.0
-numpy>=1.25
+numpy>=1.24
 cython>=3.0.0
 scipy>=1.11.1


### PR DESCRIPTION
This PR decreases the required NumPy version from 1.25 to 1.24. The library works just fine on 1.24. The problem with 1.25 is that it dropped support for Python 3.8 and there are still live systems running on that version that can benefit from integrating `isotree`.